### PR TITLE
Update Actions workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # Cache LFS files between runs to avoid GitHub.com cost overruns
       - name: Checkout code
-        uses: nschloe/action-cached-lfs-checkout@main
+        uses: astre471/action-cached-lfs-checkout@main
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll


### PR DESCRIPTION
Update the actions workflow to fix the deprecation warning issue with node16:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
